### PR TITLE
Deduplicate the shared nodes between segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can install this software using pip:
 
 ### Running
 
-See demo.py for example usage 
+See demo.py for example usage
 
 path(start_pose, end_pose, turn_radius, runway_length, step_size, length_tolerance (optional))
 - return a Reeds-Shepp path from start_pose to end_pose with specified turning radius and step_size between points. The length_tolerance default is 2 meters but can be set to user preference — if paths’ total lengths are within length tolerance of each other, the path function will choose the one with fewer segments as the optimal path. The runway_length is for the runway at the end of the path that helps improve accuracy in reaching the final position — this can be set to 0, or a positive or negative number for a forwards or backwards driving runway.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rsplan"
-version = "1.0.7"
+version = "1.0.8"
 description = "Reeds-Shepp algorithm implementation in Python"
 readme = "README.md"
 authors = [{ name = "Built Robotics", email = "tarakapoor9@gmail.com" }]

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -84,11 +84,11 @@ class Path:
 
         # Calculate list of Waypoint parameter tuples for non-runway segments
         for ix, segment in enumerate(self.segments):
-            if self._has_runway and ix == len(self.segments) - 1:
+            if self._has_runway and ix == len(self.segments) - 1:  # Runway segment
                 seg_points = segment.calc_waypoints(
                     (x0, y0, yaw0), self.step_size, True, end_pose=self.end_pose
                 )
-            else:
+            else:  # Non-runway segment
                 seg_points = segment.calc_waypoints(
                     (x0, y0, yaw0), self.step_size, False
                 )
@@ -309,9 +309,8 @@ class Segment:
         # straight segments) and dtheta (step size / turn radius) for curved segments.
         step = step_size if self.is_straight else step_size / self.turn_radius
 
-        # Since np.arrange does not handle floating point arithmetic well, we use
-        # linspace and the slightly awkward step of calculating the number of steps.
-        num_steps = math.ceil(magnitude / step_size)
-        seg_pts = np.linspace(0, magnitude, num_steps, endpoint=True)
 
-        return seg_pts
+        # Prefer linspace to arange to avoid floating point errors. Will distribute
+        # remainder distance across steps instead of having a short final step.
+        num_steps = math.ceil(magnitude / step)
+        return np.linspace(0, magnitude, num_steps, endpoint=True)

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -309,6 +309,9 @@ class Segment:
         # straight segments) and dtheta (step size / turn radius) for curved segments.
         step = step_size if self.is_straight else step_size / self.turn_radius
 
-        seg_pts = np.linspace(0, magnitude, math.ceil(magnitude/step), endpoint=True)
+        # Since np.arrange does not handle floating point arithmetic well, we use
+        # linspace and the slightly awkward step of calculating the number of steps.
+        num_steps = math.ceil(magnitude / step)
+        seg_pts = np.linspace(0, magnitude, num_steps, endpoint=True)
 
         return seg_pts

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -5,6 +5,7 @@ import functools
 from typing import Any, List, Literal, Optional, Tuple
 
 import numpy as np
+import math
 
 from rsplan import helpers
 
@@ -308,9 +309,6 @@ class Segment:
         # straight segments) and dtheta (step size / turn radius) for curved segments.
         step = step_size if self.is_straight else step_size / self.turn_radius
 
-        seg_pts = np.arange(0, magnitude, step)
-
-        # Add segment endpoint if the list of segment points is not empty
-        seg_pts = np.append(seg_pts, [magnitude]) if seg_pts.any() else np.array([0.0])
+        seg_pts = np.linspace(0, magnitude, math.ceil(magnitude/step), endpoint=True)
 
         return seg_pts

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -83,22 +83,23 @@ class Path:
 
         # Calculate list of Waypoint parameter tuples for non-runway segments
         for ix, segment in enumerate(self.segments):
-            if self._has_runway and ix == len(self.segments) - 1:  # Runway segment
+            if self._has_runway and ix == len(self.segments) - 1: # Runway segment
                 seg_points = segment.calc_waypoints(
                     (x0, y0, yaw0), self.step_size, True, end_pose=self.end_pose
                 )
-                # Remove duplicated runway starting point
-                if Waypoint(*path_points[-1]).is_close(Waypoint(*seg_points[0])):
-                    seg_points.pop(0)
-            else:  # Non-runway segment
+            else:
                 seg_points = segment.calc_waypoints(
                     (x0, y0, yaw0), self.step_size, False
                 )
 
+            # Remove the duplicated start/end waypoint when combining segments
+            if ix > 0 and Waypoint(*path_points[-1]).is_close(Waypoint(*seg_points[0])):
+                seg_points.pop(0)
+
             path_points.extend(seg_points)  # Add segment pts to list of path pts
 
-            # For next segment, set first point to last pt of this segment
-            x0, y0, yaw0 = seg_points[-1][0], seg_points[-1][1], seg_points[-1][2]
+            # For next segment, set first point to last pt in the current path
+            x0, y0, yaw0 = path_points[-1][0], path_points[-1][1], path_points[-1][2]
 
         # Ensures that the path's last pt equals the provided end pt by appending end pt
         # to the list of path pts if the last pt in the path is not the end pt

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -311,7 +311,7 @@ class Segment:
 
         # Since np.arrange does not handle floating point arithmetic well, we use
         # linspace and the slightly awkward step of calculating the number of steps.
-        num_steps = math.ceil(magnitude / step)
+        num_steps = int((magnitude / step_size) + 1)
         seg_pts = np.linspace(0, magnitude, num_steps, endpoint=True)
 
         return seg_pts

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -311,7 +311,7 @@ class Segment:
 
         # Since np.arrange does not handle floating point arithmetic well, we use
         # linspace and the slightly awkward step of calculating the number of steps.
-        num_steps = int((magnitude / step_size) + 1)
+        num_steps = math.ceil(magnitude / step_size)
         seg_pts = np.linspace(0, magnitude, num_steps, endpoint=True)
 
         return seg_pts

--- a/rsplan/unit_tests.py
+++ b/rsplan/unit_tests.py
@@ -88,7 +88,7 @@ def test_straight_path(
     )
 
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert wp1 != wp2
+        assert not wp1.is_close(wp2)
 
     assert len(set(wp.driving_direction for wp in nav_path.waypoints())) == 1
 
@@ -100,13 +100,13 @@ def test_backward_path(yaw_angle: float) -> None:
     assert nav_path is not None
     assert nav_path.total_length >= helpers.euclidean_distance(_ORIGIN, end)
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert wp1 != wp2
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
     nav_path2 = _nav_path(_ROTATED, end)
     assert nav_path2 is not None
     assert nav_path.total_length >= helpers.euclidean_distance(_ORIGIN, end)
     for wp1, wp2 in zip(nav_path2.waypoints()[:-1], nav_path2.waypoints()[1:]):
-        assert wp1 != wp2
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
 
 @pytest.mark.parametrize(
@@ -131,7 +131,8 @@ def test_path_no_runway(
     assert all(waypoint.is_runway is False for waypoint in nav_path.waypoints())
 
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert wp1 != wp2
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
+
 
 
 @pytest.mark.parametrize("seed", range(100))
@@ -158,13 +159,9 @@ def test_random_path(seed: int) -> None:
     assert nav_path.start_pose == start
     assert nav_path.end_pose == end
 
-    for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert wp1 != wp2
-
     # No consecutive duplicates
-    waypoints = nav_path.waypoints()
-    for i in range(len(waypoints)-1):
-        assert not waypoints[i].is_close(waypoints[i+1])
+    for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
 
 def main() -> None:

--- a/rsplan/unit_tests.py
+++ b/rsplan/unit_tests.py
@@ -162,5 +162,31 @@ def test_random_path(seed: int) -> None:
         assert wp1 != wp2
 
 
+@pytest.mark.parametrize("seed", range(100))
+def test_random_path_has_unique_waypoints(seed: int) -> None:
+
+    if seed <= 10:
+        start = _ORIGIN
+    else:
+        rng0 = np.random.default_rng(seed + 100)
+        x0 = _RANDOM_PATH_DISTANCE_RANGE * rng0.uniform(-1, 1)
+        y0 = _RANDOM_PATH_DISTANCE_RANGE * rng0.uniform(-1, 1)
+        yaw0 = _RANDOM_PATH_ANGLE_RANGE * rng0.random()
+        start = (x0, y0, yaw0)
+
+    rng = np.random.default_rng(seed)
+    x = _RANDOM_PATH_DISTANCE_RANGE * rng.uniform(-1, 1)
+    y = _RANDOM_PATH_DISTANCE_RANGE * rng.uniform(-1, 1)
+    yaw = _RANDOM_PATH_ANGLE_RANGE * rng.random()
+    end = (x, y, yaw)
+
+    nav_path = _nav_path(start, end)
+
+    waypoints = nav_path.waypoints()
+    for i in range(len(waypoints)-1):
+        assert not waypoints[i].is_close(waypoints[i+1]):
+
+
 def main() -> None:
-    test_random_path()
+    # test_random_path()
+    test_random_path_has_unique_waypoints(45)

--- a/rsplan/unit_tests.py
+++ b/rsplan/unit_tests.py
@@ -88,7 +88,7 @@ def test_straight_path(
     )
 
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert not wp1.is_close(wp2)
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
     assert len(set(wp.driving_direction for wp in nav_path.waypoints())) == 1
 
@@ -100,13 +100,13 @@ def test_backward_path(yaw_angle: float) -> None:
     assert nav_path is not None
     assert nav_path.total_length >= helpers.euclidean_distance(_ORIGIN, end)
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert not wp1.is_close(wp2)
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
     nav_path2 = _nav_path(_ROTATED, end)
     assert nav_path2 is not None
     assert nav_path.total_length >= helpers.euclidean_distance(_ORIGIN, end)
     for wp1, wp2 in zip(nav_path2.waypoints()[:-1], nav_path2.waypoints()[1:]):
-        assert not wp1.is_close(wp2)
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
 
 @pytest.mark.parametrize(
@@ -131,7 +131,7 @@ def test_path_no_runway(
     assert all(waypoint.is_runway is False for waypoint in nav_path.waypoints())
 
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert not wp1.is_close(wp2)
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
 
 
@@ -161,7 +161,7 @@ def test_random_path(seed: int) -> None:
 
     # No consecutive duplicates
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert not wp1.is_close(wp2)
+        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
 
 def main() -> None:

--- a/rsplan/unit_tests.py
+++ b/rsplan/unit_tests.py
@@ -100,13 +100,13 @@ def test_backward_path(yaw_angle: float) -> None:
     assert nav_path is not None
     assert nav_path.total_length >= helpers.euclidean_distance(_ORIGIN, end)
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
+        assert not wp1.is_close(wp2)
 
     nav_path2 = _nav_path(_ROTATED, end)
     assert nav_path2 is not None
     assert nav_path.total_length >= helpers.euclidean_distance(_ORIGIN, end)
     for wp1, wp2 in zip(nav_path2.waypoints()[:-1], nav_path2.waypoints()[1:]):
-        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
+        assert not wp1.is_close(wp2)
 
 
 @pytest.mark.parametrize(
@@ -131,7 +131,7 @@ def test_path_no_runway(
     assert all(waypoint.is_runway is False for waypoint in nav_path.waypoints())
 
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
+        assert not wp1.is_close(wp2)
 
 
 
@@ -161,7 +161,7 @@ def test_random_path(seed: int) -> None:
 
     # No consecutive duplicates
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
+        assert not wp1.is_close(wp2)
 
 
 def main() -> None:

--- a/rsplan/unit_tests.py
+++ b/rsplan/unit_tests.py
@@ -161,32 +161,11 @@ def test_random_path(seed: int) -> None:
     for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
         assert wp1 != wp2
 
-
-@pytest.mark.parametrize("seed", range(100))
-def test_random_path_has_unique_waypoints(seed: int) -> None:
-
-    if seed <= 10:
-        start = _ORIGIN
-    else:
-        rng0 = np.random.default_rng(seed + 100)
-        x0 = _RANDOM_PATH_DISTANCE_RANGE * rng0.uniform(-1, 1)
-        y0 = _RANDOM_PATH_DISTANCE_RANGE * rng0.uniform(-1, 1)
-        yaw0 = _RANDOM_PATH_ANGLE_RANGE * rng0.random()
-        start = (x0, y0, yaw0)
-
-    rng = np.random.default_rng(seed)
-    x = _RANDOM_PATH_DISTANCE_RANGE * rng.uniform(-1, 1)
-    y = _RANDOM_PATH_DISTANCE_RANGE * rng.uniform(-1, 1)
-    yaw = _RANDOM_PATH_ANGLE_RANGE * rng.random()
-    end = (x, y, yaw)
-
-    nav_path = _nav_path(start, end)
-
+    # No consecutive duplicates
     waypoints = nav_path.waypoints()
     for i in range(len(waypoints)-1):
-        assert not waypoints[i].is_close(waypoints[i+1]):
+        assert not waypoints[i].is_close(waypoints[i+1])
 
 
 def main() -> None:
-    # test_random_path()
-    test_random_path_has_unique_waypoints(45)
+    test_random_path()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name = "rsplan",
-    version = "1.0.7",
+    version = "1.0.8",
     author = "Built Robotics",
     author_email = "tarakapoor9@gmail.com",
     description = ("Reeds-Shepp algorithm implementation in Python."),


### PR DESCRIPTION
### Summary:
This patch focuses on refining the `Path.waypoints()` method to address the waypoint duplication issue and updating the interpolation mechanism
### Details: 
- Waypoint Duplication in `Path.waypoints()`
  - Problem: While generating the path of waypoints for each segment and then merging these segments, the endpoint of `segment_i` can match the starting point of `segment_i+1`, leading to duplicate waypoints connecting these segments
  - Solution: Extend the deduplication check, which was previously only applied to the runway scenario, to cover all segments.
  - Test Coverage: The unit test has been updated to assert that there are no duplicates
    - The test previously compared waypoints using `==` but this compares properties all properties of the waypoint
    - `Waypoint.curvature` and `Waypoint.is_runway` pertain to the overall segment that the waypoint is a part of rather than individual waypoints. 
    - The new test focuses on the actual coordinates or values of waypoints to ensure no duplicates exist. 
- Interpolation Enhancement:
  - Problem: The `arange()` function from numpy, as used in the current interpolation method, can sometimes produce numbers slightly beyond the designated upper boundary. ([numpy docs for arange describing "floating point overflow"](https://numpy.org/doc/stable/reference/generated/numpy.arange.html))
  - Solution:
    - Transition from `arange()` to `linspace()` for more accurate interpolation results. This guarantees a uniform and precise range of numbers (start, end).
    - The switch to `linspace()` also negates the need to manually add the final value to the sequence of interpolated numbers, ensuring a smoother and more intuitive implementation.    
  -Evidence: 
```
>>> np.arange(1, 1.5, 0.1)
array([1. , 1.1, 1.2, 1.3, 1.4])
>>> np.arange(1, 1.6, 0.1)
array([1. , 1.1, 1.2, 1.3, 1.4, 1.5, 1.6])
>>> np.arange(1, 1.6, 0.1)[-1]
1.6000000000000005

>>> np.linspace(1, 1.6, math.ceil((1.6-1)/0.1), endpoint=True)
array([1. , 1.1, 1.2, 1.3, 1.4, 1.5, 1.6])
>>> np.linspace(1, 1.6, math.ceil((1.6-1)/0.1), endpoint=True)[-1]
1.6
```
