### PR TITLE
Fix issue where linspace could return 1 value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rsplan"
-version = "1.0.9"
+version = "1.0.10"
 description = "Reeds-Shepp algorithm implementation in Python"
 readme = "README.md"
 authors = [{ name = "Built Robotics", email = "engineering@builtrobotics.com" }]

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -312,5 +312,5 @@ class Segment:
 
         # Prefer linspace to arange to avoid floating point errors. Will distribute
         # remainder distance across steps instead of having a short final step.
-        num_steps = math.ceil(magnitude / step)
+        num_steps = int((magnitude / step) + 2)
         return np.linspace(0, magnitude, num_steps, endpoint=True)

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -5,7 +5,6 @@ import functools
 from typing import Any, List, Literal, Optional, Tuple
 
 import numpy as np
-import math
 
 from rsplan import helpers
 

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -308,8 +308,9 @@ class Segment:
         # straight segments) and dtheta (step size / turn radius) for curved segments.
         step = step_size if self.is_straight else step_size / self.turn_radius
 
-
+        # Calculate num_steps to guarantee at least 2 points (start and end),
+        # addressing cases where magnitude < step size.
+        num_steps = int((magnitude / step) + 2)
         # Prefer linspace to arange to avoid floating point errors. Will distribute
         # remainder distance across steps instead of having a short final step.
-        num_steps = int((magnitude / step) + 2)
         return np.linspace(0, magnitude, num_steps, endpoint=True)

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-from typing import Any, List, Literal, Optional, Tuple
+from typing import Any, List, Literal, Tuple
 
 import numpy as np
 

--- a/rsplan/primitives.py
+++ b/rsplan/primitives.py
@@ -101,26 +101,8 @@ class Path:
             # For next segment, set first point to last pt in the current path
             x0, y0, yaw0 = path_points[-1][0], path_points[-1][1], path_points[-1][2]
 
-        # Ensures that the path's last pt equals the provided end pt by appending end pt
-        # to the list of path pts if the last pt in the path is not the end pt
-        end_pose_to_add = self._end_pose_to_add(path_points[-1])
-        path_points.append(end_pose_to_add) if end_pose_to_add is not None else ()
-
         return [Waypoint(*point) for point in path_points]
 
-    def _end_pose_to_add(
-        self, last_path_pt: Tuple[float, float, float, float, Literal[-1, 1], bool]
-    ) -> Optional[Tuple[float, float, float, float, Literal[-1, 1], bool]]:
-        """Checks if the last path point equals the provided Path end point. It's
-        possible for end points to be slightly off the target end pose due to path
-        discretization with a non-ideal step size.
-        """
-        end_pose_with_params = (*self.end_pose, *last_path_pt[3:])
-        if not Waypoint(*last_path_pt).is_close(Waypoint(*end_pose_with_params)):
-            # Point to append is end point with last 3 parameters from final path point
-            return end_pose_with_params
-
-        return None
 
     def __hash__(self) -> int:
         segment_tuple = tuple(
@@ -221,13 +203,12 @@ class Segment:
         length and curvature) to calculate the list of points used to represent this
         segment.
         """
-        if self.is_straight and end_pose != (0.0, 0.0, 0.0):
-            # Runway segment with end point passed in for accuracy
-            xs, ys, yaws = self._straight_runway_pts(start_pose, end_pose, step_size)
-        else:
-            # Non-runway segment
-            segment_points = self._interpolated(step_size)
-            xs, ys, yaws = self._get_segment_coords(start_pose, segment_points)
+        segment_points = self._interpolated(step_size)
+        xs, ys, yaws = self._get_segment_coords(start_pose, segment_points)
+
+        # If it is a runway we want to use the end_pose yaw
+        if is_runway:
+            yaws = [end_pose[-1] for _ in yaws]
 
         return [
             (xs[i], ys[i], yaws[i], self._curvature(), self.direction, is_runway)
@@ -244,22 +225,6 @@ class Segment:
             return -1.0 / self.turn_radius
         return 0.0
 
-    def _straight_runway_pts(
-        self,
-        start: Tuple[float, float, float],
-        end: Tuple[float, float, float],
-        step_size: float,
-    ) -> Tuple[list[float], list[float], list[float]]:
-        """Calculate a straight line of coordinates from the runway start pose to the
-        runway end pose using the yaw angle of the runway end pose to ensure the
-        runway coordinates are accurate.
-        """
-        num_coords = int((self.length / step_size) + 2)
-        x_coords = (np.linspace(start[0], end[0], num=num_coords, dtype=float)).tolist()
-        y_coords = (np.linspace(start[1], end[1], num=num_coords, dtype=float)).tolist()
-        yaw_coords = (np.ones(num_coords) * end[2]).tolist()
-
-        return x_coords, y_coords, yaw_coords
 
     def _get_segment_coords(
         self,
@@ -307,7 +272,6 @@ class Segment:
         # step is the distance between points along the segment: dl (linear distance for
         # straight segments) and dtheta (step size / turn radius) for curved segments.
         step = step_size if self.is_straight else step_size / self.turn_radius
-
         # Calculate num_steps to guarantee at least 2 points (start and end),
         # addressing cases where magnitude < step size.
         num_steps = int((magnitude / step) + 2)

--- a/rsplan/unit_tests.py
+++ b/rsplan/unit_tests.py
@@ -168,5 +168,6 @@ def test_random_path(seed: int) -> None:
         # No individual distance is greater than the step size
         assert round(helpers.euclidean_distance(wp1_pose, wp2_pose), 2) <= _STEP_SIZE
 
+
 def main() -> None:
     test_random_path()

--- a/rsplan/unit_tests.py
+++ b/rsplan/unit_tests.py
@@ -159,10 +159,14 @@ def test_random_path(seed: int) -> None:
     assert nav_path.start_pose == start
     assert nav_path.end_pose == end
 
-    # No consecutive duplicates
-    for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
-        assert wp1.pose_2d_tuple != wp2.pose_2d_tuple
 
+    for wp1, wp2 in zip(nav_path.waypoints()[:-1], nav_path.waypoints()[1:]):
+        wp1_pose = wp1.pose_2d_tuple
+        wp2_pose = wp2.pose_2d_tuple
+        # No consecutive duplicates
+        assert wp1_pose != wp2_pose
+        # No individual distance is greater than the step size
+        assert round(helpers.euclidean_distance(wp1_pose, wp2_pose), 2) <= _STEP_SIZE
 
 def main() -> None:
     test_random_path()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name = "rsplan",
-    version = "1.0.9",
+    version = "1.0.10",
     author = "Built Robotics",
     author_email = "engineering@builtrobotics.com",
     description = ("Reeds-Shepp algorithm implementation in Python."),


### PR DESCRIPTION
Issue in `_interpolated` method of the `Segment` class
Problem:
- If the segment's length is less than the given step size, the formula to compute the number of steps for np.linspace can yield a result of 1
- Consequently, the waypoints calculation may return just the starting point of the segment, disregarding the endpoint—due to being closer than the step size
- In these scenarios, while smaller step sizes are permissible, it's essential that the segment's waypoints always start at the segment's beginning and conclude at its end
- current num_steps calculation ex:
```
>>> magnitude = 0.3
>>> step_size = 0.5
>>> num_steps = math.ceil(magnitude/step_size)
>>> np.linspace(0, magnitude, num_steps, endpoint=True)
array([0.])
```
Solution:
- Adopt the method for computing the number of points from `_straight_runway_pts`, which is: `num_steps = int((magnitude / step) + 2)`
- This ensures the minimum amount of points is 2, so that the `start` and `end` will be in the calculated waypoints for the segment
- new num_steps calculation ex:
```
>>> magnitude = 0.3
>>> step_size = 0.5
>>> num_steps = int((magnitude/step_size) + 2)
>>> np.linspace(0, magnitude, num_steps, endpoint=True)
array([0. , 0.3])
```

Modified the random paths unit tests, to check that each waypoint is less than or equal to the step size distance away from the previous waypoint